### PR TITLE
Add state save/load options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ usage: cipdgol.py [--birth-threshold MIN MAX]
                   [-g WIDTH HEIGHT] [-n STEPS]
                   [-f FPS] [-c CMAP]
                   [-o OUTPUT]
+                  [--save-state FILE]
+                  [--load-state FILE]
 ```
 
 ### Example
 ```bash
-python cipdgol.py --birth-threshold 0.3 0.7 --survival-threshold 0.2 0.9 --time-steps 500 --fps 60 -g 1024 1024 -o simulation.mp4
+python cipdgol.py --birth-threshold 0.3 0.7 --survival-threshold 0.2 0.9 --time-steps 500 --fps 60 -g 1024 1024 -o simulation.mp4 --save-state final.npy
 ```
 
 ## Parameters Explained
@@ -66,13 +68,13 @@ python cipdgol.py -o output.mp4
 ```
 
 ## Save and Load States
-Save the current state:
+Save the current state while exporting:
 ```bash
-python cipdgol.py --save-state state.npy
+python cipdgol.py -o output.mp4 --save-state state.npy
 ```
-Load a previously saved state:
+Load a previously saved state and continue:
 ```bash
-python cipdgol.py --load-state state.npy
+python cipdgol.py --load-state state.npy --time-steps 100 --save-state next.npy -o next.mp4
 ```
 
 ## Contribute

--- a/cipdgol.py
+++ b/cipdgol.py
@@ -215,6 +215,16 @@ def parse_args(args):
     argp.add_argument(
         "-o", "--output-path", type=str, help="Output path for video export"
     )
+    argp.add_argument(
+        "--save-state",
+        type=str,
+        help="Path to save the final simulation state",
+    )
+    argp.add_argument(
+        "--load-state",
+        type=str,
+        help="Path to load a saved simulation state",
+    )
 
     return argp.parse_args()
 
@@ -236,6 +246,9 @@ def main(args):
     }
     game = CIPDGOL(**cipdgol_params)
 
+    if params.load_state:
+        game.load_state(params.load_state)
+
     export_params = {
         "grid_size": tuple(params.grid_size),
         "time_steps": params.time_steps,
@@ -244,6 +257,8 @@ def main(args):
         "output_path": params.output_path,
     }
     game.export(**export_params)
+    if params.save_state:
+        game.save_state(params.save_state)
     game.export_history(f"{hash(game)}.npy")
 
 


### PR DESCRIPTION
## Summary
- allow saving and loading state from CLI
- document new `--save-state` and `--load-state` options

## Testing
- `python cipdgol.py --help | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_68409b60f3c0832887db17f7ef324d3d