### PR TITLE
Change default for store_history

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python cipdgol.py --birth-threshold 0.3 0.7 --survival-threshold 0.2 0.9 --time-
 - **-f / --fps** – Frames per second for export.
 - **-o / --output-path** – Path to save exported video.
 - **-x / --clip** – Clip cell values between 0 and 1.
-- **-t / --store-history** – Store historical grid states.
+- **-t / --store-history** – Store historical grid states (disabled by default).
 
 ## Exporting
 Export your simulation to video:

--- a/cipdgol.py
+++ b/cipdgol.py
@@ -29,7 +29,7 @@ class CIPDGOL:
         influence,
         seed=None,
         clip=False,
-        store_history=True,
+        store_history=False,
     ):
         self.rng = (
             np.random.default_rng(seed) if seed is not None else np.random.default_rng()
@@ -192,7 +192,10 @@ def parse_args(args):
         "-x", "--clip", action="store_true", help="Clip state values between 0 and 1"
     )
     argp.add_argument(
-        "-t", "--store-history", action="store_true", help="Store state history"
+        "-t",
+        "--store-history",
+        action="store_true",
+        help="Store state history (disabled by default)",
     )
 
     argp.add_argument(


### PR DESCRIPTION
## Summary
- default `CIPDGOL.store_history` to `False`
- mention default for the `--store-history` flag in CLI help
- note the disabled default in README

## Testing
- `python cipdgol.py -h | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68409b6151808328af85cc7b01a71a20