### PR TITLE
Add updates_per_step option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ usage: cipdgol.py [--birth-threshold MIN MAX]
                   [--influence FLOAT]
                   [-s SEED] [-x] [-t]
                   [-g WIDTH HEIGHT] [-n STEPS]
-                  [-f FPS] [-c CMAP]
+                  [-f FPS] [--updates-per-step INT] [-c CMAP]
                   [-o OUTPUT]
                   [--save-state FILE]
                   [--load-state FILE]
@@ -56,6 +56,7 @@ python cipdgol.py --birth-threshold 0.3 0.7 --survival-threshold 0.2 0.9 --time-
 - **-g / --grid-size** – Grid size (width, height).
 - **-n / --time-steps** – Number of simulation steps.
 - **-f / --fps** – Frames per second for export.
+- **--updates-per-step** – Number of internal updates performed each step.
 - **-o / --output-path** – Path to save exported video.
 - **-x / --clip** – Clip cell values between 0 and 1.
 - **-t / --store-history** – Store historical grid states (disabled by default).

--- a/cipdgol.py
+++ b/cipdgol.py
@@ -97,7 +97,13 @@ class CIPDGOL:
         self._idx = 0
         self._state_history.clear()
 
-    def simulate(self, grid_size=(512, 512), time_steps=100, real_time=False):
+    def simulate(
+        self,
+        grid_size=(512, 512),
+        time_steps=100,
+        real_time=False,
+        updates_per_step=2,
+    ):
         """simulates for time_steps steps"""
         self._initialize_state(grid_size)
 
@@ -108,8 +114,8 @@ class CIPDGOL:
 
         for i in looper:
             yield self._state
-            self._update()
-            self._update()
+            for _ in range(updates_per_step):
+                self._update()
             if real_time:
                 plt.imshow(self._state, cmap="magma", vmin=0, vmax=1)
                 plt.pause(0.01)
@@ -121,6 +127,7 @@ class CIPDGOL:
         fps=30,
         cmap="magma",
         output_path=None,
+        updates_per_step=2,
     ):
         """exports animation to video"""
 
@@ -143,8 +150,8 @@ class CIPDGOL:
                 end="\r",
             )
 
-            self._update()
-            self._update()
+            for _ in range(updates_per_step):
+                self._update()
             cax.set_array(self._state)
             self._idx += 1
             return (cax,)
@@ -215,6 +222,12 @@ def parse_args(args):
         "-f", "--fps", type=int, default=30, help="Frames per second for export"
     )
     argp.add_argument(
+        "--updates-per-step",
+        type=int,
+        default=2,
+        help="Number of internal updates per simulation step",
+    )
+    argp.add_argument(
         "-c", "--cmap", type=str, default="magma", help="Colormap for visualization"
     )
     argp.add_argument(
@@ -260,6 +273,7 @@ def main(args):
         "fps": params.fps,
         "cmap": params.cmap,
         "output_path": params.output_path,
+        "updates_per_step": params.updates_per_step,
     }
     game.export(**export_params)
 

--- a/tests/test_cipdgol.py
+++ b/tests/test_cipdgol.py
@@ -19,7 +19,7 @@ def test_simulation_step():
         seed=42,
     )
 
-    sim = game.simulate(grid_size=(8, 8), time_steps=2)
+    sim = game.simulate(grid_size=(8, 8), time_steps=2, updates_per_step=2)
     state0 = next(sim)
     state1 = next(sim)
 


### PR DESCRIPTION
## Summary
- control internal update count with `updates_per_step`
- expose new option in CLI and docs
- update test to use the new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197ad88fc83288f948767d9295d24