### PR TITLE
Fix export state init

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Load a previously saved state and continue:
 ```bash
 python cipdgol.py --load-state state.npy --time-steps 100 --save-state next.npy -o next.mp4
 ```
+When a state file is loaded, `cipdgol.py` continues exactly from that grid
+instead of starting a new one. The `--grid-size` option is ignored in this
+situation, so the exported video begins with the loaded state.
 
 ## Contribute
 Feel free to fork, improve, and submit pull requests. Let's evolve EvolveScape together!

--- a/cipdgol.py
+++ b/cipdgol.py
@@ -99,7 +99,8 @@ class CIPDGOL:
 
     def simulate(self, grid_size=(512, 512), time_steps=100, real_time=False):
         """simulates for time_steps steps"""
-        self._initialize_state(grid_size)
+        if self._state is None:
+            self._initialize_state(grid_size)
 
         if time_steps > 0:
             looper = range(time_steps)
@@ -124,7 +125,8 @@ class CIPDGOL:
     ):
         """exports animation to video"""
 
-        self._initialize_state(grid_size)
+        if self._state is None:
+            self._initialize_state(grid_size)
 
         if output_path is None:
             output_path = f"{uuid.uuid4()}.mp4"

--- a/tests/test_cipdgol.py
+++ b/tests/test_cipdgol.py
@@ -3,8 +3,10 @@ import sys
 from pathlib import Path
 
 import pytest
+import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import cipdgol
 from cipdgol import CIPDGOL
 
 
@@ -25,3 +27,59 @@ def test_simulation_step():
 
     assert state0.shape == (8, 8)
     assert state1.shape == (8, 8)
+
+
+def test_export_uses_loaded_state(monkeypatch, tmp_path):
+    import matplotlib
+    matplotlib.use("Agg")
+
+    game = CIPDGOL(
+        birth_threshold=(0.25, 0.75),
+        survival_threshold=(0.2, 0.8),
+        decay_rate=0.1,
+        birth_rate=0.5,
+        survival_rate=0.1,
+        influence=3.0,
+        seed=1,
+    )
+
+    sim = game.simulate(grid_size=(4, 4), time_steps=1)
+    next(sim)
+    state_path = tmp_path / "state.npy"
+    game.save_state(state_path)
+
+    game2 = CIPDGOL(
+        birth_threshold=(0.25, 0.75),
+        survival_threshold=(0.2, 0.8),
+        decay_rate=0.1,
+        birth_rate=0.5,
+        survival_rate=0.1,
+        influence=3.0,
+        seed=2,
+    )
+
+    game2.load_state(state_path)
+    loaded_state = game2._state.copy()
+
+    def fail_init(grid_size):
+        raise AssertionError("_initialize_state should not be called")
+
+    monkeypatch.setattr(game2, "_initialize_state", fail_init)
+    monkeypatch.setattr(game2, "_update", lambda: None)
+
+    class DummyAnim:
+        def save(self, output_path, fps=30, extra_args=None):
+            Path(output_path).touch()
+
+    def dummy_funcanimation(fig, animate, frames):
+        for i in range(frames):
+            animate(i)
+        return DummyAnim()
+
+    monkeypatch.setattr(cipdgol.animation, "FuncAnimation", dummy_funcanimation)
+
+    out_file = tmp_path / "out.mp4"
+    game2.export(grid_size=(8, 8), time_steps=1, output_path=out_file)
+
+    assert out_file.exists()
+    assert np.array_equal(game2._state, loaded_state)


### PR DESCRIPTION
## Summary
- avoid overwriting loaded state in `CIPDGOL.export`
- test that export resumes from a loaded state
- clarify state loading behaviour in README

## Testing
- `pip install numpy matplotlib scipy --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197b2b83c83289f6da1683691d1c1