### PR TITLE
Remove unused imports and add flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E402

--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ pip install pytest
 pytest
 ```
 
+For style checks, install `flake8` and run it from the project root:
+```bash
+pip install flake8
+flake8
+```
+

--- a/cipdgol.py
+++ b/cipdgol.py
@@ -266,5 +266,6 @@ def main(args):
     if params.store_history:
         game.export_history(f"{hash(game)}.npy")
 
+
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/tests/test_cipdgol.py
+++ b/tests/test_cipdgol.py
@@ -1,10 +1,8 @@
-import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from cipdgol import CIPDGOL
 
 


### PR DESCRIPTION
## Summary
- clean up `tests/test_cipdgol.py`
- add a style check config
- document style checks in README
- ensure PEP8 compliance at script entry point

## Testing
- `flake8 tests/test_cipdgol.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684197b1004883288dc8ed519323b805